### PR TITLE
Fix Problem079: use Environment.NewLine for cross-platform compatibility

### DIFF
--- a/ProjectEuler/Problems/001-100/71-80/Problem079.cs
+++ b/ProjectEuler/Problems/001-100/71-80/Problem079.cs
@@ -9,7 +9,7 @@ public class Problem079 : IProblem
     public async Task<string> CalculateAsync(string[] args)
     {
         var textFile = await File.ReadAllTextAsync("Problems/001-100/71-80/Problem079_keylog.txt");
-        var entries = textFile.Split("\n", StringSplitOptions.RemoveEmptyEntries);
+        var entries = textFile.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         var digits = entries.SelectMany(x => x).Distinct();
         var values = digits.ToDictionary(x => x, _ => (int?)null);
         foreach (var entry in entries)


### PR DESCRIPTION
## Summary
- Replace hardcoded `\n` with `Environment.NewLine` in Problem079 keylog file parsing
- Ensures correct line splitting on Windows where line endings are `\r\n`

## Test plan
- [ ] Run Problem079 solution and verify it produces the correct answer

Generated with [Claude Code](https://claude.com/claude-code)